### PR TITLE
fix: remove comma to fix syntax error in JSON

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
     "packages": {
-        "trafix": {},
+        "trafix": {}
     },
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": false,


### PR DESCRIPTION
Remove a comma in release-please-config.json on last item in JSON map, as that violates the JSON syntax.

### What?
Fix syntax error in release-please-config.json

### Why?
This fixes the issue with release-please not working correctly. 

### Checklist
- [x] Tests are added/updated.
- [x] Documentation is added/updated.
- [x] Self-review of code changes completed.