### PR TITLE
docs: introduce missing documentation enforced by clippy

### DIFF
--- a/trafix-codec/src/constants/mod.rs
+++ b/trafix-codec/src/constants/mod.rs
@@ -1,3 +1,5 @@
+//! Constants used during encoding and decoding.
+
 /// ASCII SOH delimiter (0x01) used as field terminator in FIX messages.
 pub(crate) const SOH: u8 = b'\x01';
 

--- a/trafix-codec/src/decoder/decode.rs
+++ b/trafix-codec/src/decoder/decode.rs
@@ -47,7 +47,13 @@ pub enum Error {
     #[error(
         "calculated and expected checksums don't match 'calculated({calculated}) != ({expected})'"
     )]
-    ChecksumMismatch { calculated: u8, expected: u8 },
+    ChecksumMismatch {
+        /// Checksum calculated from the message.
+        calculated: u8,
+
+        /// Expected checksum as per the FIX protocols defined algorithm.
+        expected: u8,
+    },
 
     /// Message contains invalid tag values.
     #[error("invalid tag: {}", .0)]
@@ -55,7 +61,13 @@ pub enum Error {
 
     /// Message body length does not match what was received.
     #[error("expected body length {expected} but received {received} bytes")]
-    BodyLength { received: usize, expected: usize },
+    BodyLength {
+        /// `BodyLength` received in the message.
+        received: usize,
+
+        /// Expected `BodyLength` as per the FIX protocols defined algorithm.
+        expected: usize,
+    },
 
     /// Message contains invalid bytes.
     #[error("encountered error while parsing tokens: {}", .0)]
@@ -71,7 +83,13 @@ pub enum Error {
 pub enum LexError {
     /// Found different byte than what was expected.
     #[error("Expected '{expected}' but got {but_got}")]
-    Unexpected { expected: u8, but_got: u8 },
+    Unexpected {
+        /// Byte value that was expected at the current lexer position.
+        expected: u8,
+
+        /// Byte value that was encountered instead of the expected one.
+        but_got: u8,
+    },
 
     /// EOI reached but not expected.
     #[error("Unexpected end of input")]

--- a/trafix-codec/src/decoder/decode.rs
+++ b/trafix-codec/src/decoder/decode.rs
@@ -51,7 +51,7 @@ pub enum Error {
         /// Checksum calculated from the message.
         calculated: u8,
 
-        /// Expected checksum as per the FIX protocols defined algorithm.
+        /// Expected checksum that was extracted from the FIX message.
         expected: u8,
     },
 

--- a/trafix-codec/src/decoder/mod.rs
+++ b/trafix-codec/src/decoder/mod.rs
@@ -1,5 +1,6 @@
-//! Implementation of the Message decoder.
-
+//! Implementation of the [`Message`] decoder.
+//!
+//! [`Message`]: crate::message::Message
 mod decode;
 pub mod num;
 

--- a/trafix-codec/src/decoder/mod.rs
+++ b/trafix-codec/src/decoder/mod.rs
@@ -1,3 +1,5 @@
+//! Implementation of the Message decoder.
+
 mod decode;
 pub mod num;
 

--- a/trafix-codec/src/decoder/num.rs
+++ b/trafix-codec/src/decoder/num.rs
@@ -1,3 +1,5 @@
+//! Integer parsing utilities for FIX decoding.
+
 /// The error type returned on failed parsing of integers from byte slices.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub(crate) enum ParseIntError {

--- a/trafix-codec/src/digest.rs
+++ b/trafix-codec/src/digest.rs
@@ -1,3 +1,5 @@
+//! Implementation of a lightweight, stateful FIX checksum (Digest) calculator.
+
 /// The [`Digest`] maintains a running checksum by performing modulo-256 addition over all
 /// processed bytes, exactly as defined by the FIX checksum algorithm. This is typically used while
 /// encoding and decoding FIX messages.
@@ -18,6 +20,8 @@
 /// ```
 #[derive(Default)]
 pub(crate) struct Digest {
+    /// Accumulated checksum value computed as the modulo-256 sum of all bytes
+    /// processed, per the FIX protocol checksum definition.
     checksum: u8,
 }
 

--- a/trafix-codec/src/encoder/mod.rs
+++ b/trafix-codec/src/encoder/mod.rs
@@ -1,4 +1,6 @@
-//! Implementation of the Message encoder.
+//! Implementation of the [`Message`] encoder.
+//!
+//! [`Message`]: crate::message::Message
 
 use bytes::{BufMut, Bytes, BytesMut};
 

--- a/trafix-codec/src/lib.rs
+++ b/trafix-codec/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::pedantic)]
 #![warn(missing_docs)]
+#![warn(clippy::missing_docs_in_private_items)]
 #![forbid(unsafe_code)]
 
 //! `trafix-codec` is a low-level library for high-performance parsing,
@@ -9,5 +10,5 @@ mod digest;
 
 pub(crate) mod constants;
 pub(crate) mod decoder;
-pub mod encoder;
+pub(crate) mod encoder;
 pub mod message;


### PR DESCRIPTION
### What?
This PR introduces the `clippy::missing_docs_in_private_items` warn rule.

### Why?
To uphold high quality, easy maintenance and enable contributors to become productive as fast as possible.

### How?
By introducing the `clippy::missing_docs_in_private_items` in `lib.rs` and adding the missing doc comments.

### Notes
N/A

### Checklist
- [x] Tests are added/updated.
- [x] Documentation is added/updated.
- [x] Self-review of code changes completed.

### Related Issues
Closes #22 